### PR TITLE
Add image caching service

### DIFF
--- a/MakeCampaign/Dependencies/ImageCache.swift
+++ b/MakeCampaign/Dependencies/ImageCache.swift
@@ -1,0 +1,31 @@
+import Dependencies
+import UIKit
+
+struct ImageCache {
+    var image: @Sendable (NSData) -> UIImage?
+    var insert: @Sendable (UIImage, NSData) -> Void
+}
+
+extension ImageCache: DependencyKey {
+    static let liveValue: Self = {
+        let cache = NSCache<NSData, UIImage>()
+        return Self(
+            image: { key in cache.object(forKey: key) },
+            insert: { image, key in cache.setObject(image, forKey: key) }
+        )
+    }()
+
+    static let previewValue = Self(
+        image: { _ in nil },
+        insert: { _, _ in }
+    )
+
+    static let testValue = Self.previewValue
+}
+
+extension DependencyValues {
+    var imageCache: ImageCache {
+        get { self[ImageCache.self] }
+        set { self[ImageCache.self] = newValue }
+    }
+}

--- a/MakeCampaign/Features/Campaigns/CampaignsListView.swift
+++ b/MakeCampaign/Features/Campaigns/CampaignsListView.swift
@@ -7,6 +7,7 @@
 
 import SwiftUI
 import ComposableArchitecture
+import Dependencies
 
 struct CampaignsView: View {
     let store: StoreOf<CampaignsFeature>
@@ -150,11 +151,23 @@ struct CampaignsView: View {
 struct CampaignCardView: View {
     let campaign: Campaign
     let onSelect: (Campaign.ID) -> Void
-    
+
+    @Dependency(\.imageCache) private var imageCache
+
     var body: some View {
+        let uiImage: UIImage? = {
+            guard let imageData = campaign.image?.raw else { return nil }
+            let key = imageData as NSData
+            if let cached = imageCache.image(key) {
+                return cached
+            }
+            guard let image = UIImage(data: imageData) else { return nil }
+            imageCache.insert(image, key)
+            return image
+        }()
+
         VStack(spacing: 0) {
-            if let imageData = campaign.image?.raw,
-               let uiImage = UIImage(data: imageData) {
+            if let uiImage {
                 Group {
                     if let template = campaign.template {
                         CampaignTemplateView(campaign: campaign, template: template, image: uiImage)


### PR DESCRIPTION
## Summary
- add ImageCache service and register as dependency
- load campaign images through the cache in `CampaignCardView`

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68401719f46c832493890af31e318194